### PR TITLE
Compatibility with `h2` 0.9.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,5 @@
 (lang dune 2.7)
 
-(implicit_transitive_deps false)
-
 (generate_opam_files true)
 
 (name grpc)

--- a/dune-project
+++ b/dune-project
@@ -41,7 +41,7 @@
   (lwt
    (>= 5.0.0))
   (h2
-   (>= 0.8.0))
+   (>= 0.9.0))
   stringext))
 
 (package
@@ -53,6 +53,6 @@
   grpc
   async
   (h2
-   (>= 0.8.0))
+   (>= 0.9.0))
   h2-async
   stringext))

--- a/grpc-async.opam
+++ b/grpc-async.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "2.7"}
   "grpc"
   "async"
-  "h2" {>= "0.8.0"}
+  "h2" {>= "0.9.0"}
   "h2-async"
   "stringext"
   "odoc" {with-doc}

--- a/grpc-async.opam
+++ b/grpc-async.opam
@@ -34,5 +34,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/jeffa5/ocaml-grpc.git"
 pin-depends: [
-  [ "gluten-async.dev" "git+https://github.com/mbacarella/gluten#async-expose-ssl-options" ]
+  [ "faraday-async.dev" "git+https://github.com/bcc32/faraday#core-0.15-compat" ]
+  [ "gluten-async.dev" "git+https://github.com/anmonteiro/gluten" ]
+  [ "gluten.dev" "git+https://github.com/anmonteiro/gluten" ]
+  [ "h2-async.dev" "git+https://github.com/anmonteiro/ocaml-h2" ]
+  [ "h2.dev" "git+https://github.com/anmonteiro/ocaml-h2" ]
   ]

--- a/grpc-async.opam.template
+++ b/grpc-async.opam.template
@@ -1,3 +1,7 @@
 pin-depends: [
-  [ "gluten-async.dev" "git+https://github.com/mbacarella/gluten#async-expose-ssl-options" ]
+  [ "faraday-async.dev" "git+https://github.com/bcc32/faraday#core-0.15-compat" ]
+  [ "gluten-async.dev" "git+https://github.com/anmonteiro/gluten" ]
+  [ "gluten.dev" "git+https://github.com/anmonteiro/gluten" ]
+  [ "h2-async.dev" "git+https://github.com/anmonteiro/ocaml-h2" ]
+  [ "h2.dev" "git+https://github.com/anmonteiro/ocaml-h2" ]
   ]

--- a/grpc-lwt.opam
+++ b/grpc-lwt.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "grpc"
   "lwt" {>= "5.0.0"}
-  "h2" {>= "0.8.0"}
+  "h2" {>= "0.9.0"}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/lib/grpc-async/client.mli
+++ b/lib/grpc-async/client.mli
@@ -2,7 +2,7 @@ open! Async
 
 module Rpc : sig
   type 'a handler =
-    [ `write ] H2.Body.t -> [ `read ] H2.Body.t Deferred.t -> 'a Deferred.t
+    H2.Body.Writer.t -> H2.Body.Reader.t Deferred.t -> 'a Deferred.t
 
   val bidirectional_streaming :
     handler:
@@ -47,7 +47,7 @@ type do_request =
   ?trailers_handler:(H2.Headers.t -> unit) ->
   H2.Request.t ->
   response_handler:response_handler ->
-  [ `write ] H2.Body.t
+  H2.Body.Writer.t
 (** [do_request] is the type of a function that performs the request *)
 
 val call :

--- a/lib/grpc-async/connection.ml
+++ b/lib/grpc-async/connection.ml
@@ -11,18 +11,18 @@ let grpc_recv_streaming body buffer_w =
     (match message with
     | Some message -> Async.Pipe.write_without_pushback buffer_w message
     | None -> ());
-    H2.Body.schedule_read body ~on_read ~on_eof
+    H2.Body.Reader.schedule_read body ~on_read ~on_eof
   in
-  H2.Body.schedule_read body ~on_read ~on_eof
+  H2.Body.Reader.schedule_read body ~on_read ~on_eof
 
 let grpc_send_streaming_client body encoder_stream =
   let%map () =
     Async.Pipe.iter encoder_stream ~f:(fun encoder ->
         let payload = Grpc.Message.make encoder in
-        H2.Body.write_string body payload;
+        H2.Body.Writer.write_string body payload;
         return ())
   in
-  H2.Body.close_writer body
+  H2.Body.Writer.close body
 
 (*
 let grpc_send_streaming request encoder_stream status_mvar =
@@ -36,8 +36,8 @@ let grpc_send_streaming request encoder_stream status_mvar =
   let%bind () =
     Async.Pipe.iter encoder_stream ~f:(fun input ->
         let payload = Grpc.Message.make input in
-        H2.Body.write_string body payload;
-        H2.Body.flush body (fun () -> ());
+        H2.Body.Writer.write_string body payload;
+        H2.Body.Writer.flush body (fun () -> ());
         return ())
   in
   let%map status = Lwt_mvar.take status_mvar in
@@ -51,5 +51,5 @@ let grpc_send_streaming request encoder_stream status_mvar =
        match Grpc.Status.message status with
        | None -> []
        | Some message -> [ ("grpc-message", message) ]));
-  H2.Body.close_writer body
+  H2.Body.Writer.close body
   *)

--- a/lib/grpc-lwt/client.ml
+++ b/lib/grpc-lwt/client.ml
@@ -6,7 +6,7 @@ type do_request =
   ?trailers_handler:(H2.Headers.t -> unit) ->
   H2.Request.t ->
   response_handler:response_handler ->
-  [ `write ] H2.Body.t
+  H2.Body.Writer.t
 
 let make_request ~scheme ~service ~rpc ~headers =
   let request =
@@ -67,8 +67,7 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~(do_request : do_request)
   match out with Error _ as e -> e | Ok out -> Ok (out, status)
 
 module Rpc = struct
-  type 'a handler =
-    [ `write ] H2.Body.t -> [ `read ] H2.Body.t Lwt.t -> 'a Lwt.t
+  type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t Lwt.t -> 'a Lwt.t
 
   let bidirectional_streaming ~f write_body read_body =
     let encoder_stream, encoder_push = Lwt_stream.create () in

--- a/lib/grpc-lwt/client.mli
+++ b/lib/grpc-lwt/client.mli
@@ -1,6 +1,5 @@
 module Rpc : sig
-  type 'a handler =
-    [ `write ] H2.Body.t -> [ `read ] H2.Body.t Lwt.t -> 'a Lwt.t
+  type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t Lwt.t -> 'a Lwt.t
 
   val bidirectional_streaming :
     f:((string option -> unit) -> string Lwt_stream.t -> 'a Lwt.t) -> 'a handler
@@ -32,7 +31,7 @@ type do_request =
   ?trailers_handler:(H2.Headers.t -> unit) ->
   H2.Request.t ->
   response_handler:response_handler ->
-  [ `write ] H2.Body.t
+  H2.Body.Writer.t
 (** [do_request] is the type of a function that performs the request *)
 
 val call :


### PR DESCRIPTION
(fixes #15)

`h2` 0.9.0 introduced a breaking change by splitting `Body.t` into `Body.Reader.t` and `Body.Writer.t`. The changes are very mechanical.

Unfortunately, `faraday-async` is not being updated, and as a result `h2` is stuck on 0.8.0 on Opam, so I had to add a few pin-depends on the `async` side to make dependency resolution work.

Most of these changes are also present in https://github.com/dialohq/ocaml-grpc/pull/11 so I think we can merge that next.