### PR TITLE
Fix trailers race condition

### DIFF
--- a/examples/greeter-client-async/greeter_client_async.ml
+++ b/examples/greeter-client-async/greeter_client_async.ml
@@ -62,8 +62,8 @@ let () =
      match res with
      | Ok (res, _) ->
          printf "%s\n%!" res.message;
-         return ()
+         Async.exit 0
      | Error _ ->
          printf "an error occurred\n";
-         return ());
+         Async.exit 1);
   never_returns (Scheduler.go ())

--- a/lib/grpc-async/client.ml
+++ b/lib/grpc-async/client.ml
@@ -64,10 +64,11 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
     | `OK -> Ok handler_res
     | _ -> Error (Grpc.Status.v Grpc.Status.Unknown)
   in
-  let%bind trailers_status = Ivar.read trailers_status_ivar in
   match out with
   | Error _ as e -> return e
-  | Ok out -> return (Ok (out, trailers_status))
+  | Ok out ->
+      let%bind trailers_status = Ivar.read trailers_status_ivar in
+      return (Ok (out, trailers_status))
 
 module Rpc = struct
   type 'a handler =

--- a/lib/grpc-async/client.ml
+++ b/lib/grpc-async/client.ml
@@ -20,63 +20,51 @@ let default_headers =
   H2.Headers.of_list
     [ ("te", "trailers"); ("content-type", "application/grpc+proto") ]
 
+let trailers_handler trailers_status_ivar headers =
+  let code, message =
+    match H2.Headers.get headers "grpc-status" with
+    | None ->
+        (Grpc.Status.Unknown, Some "Expected gprc-status header, got nothing")
+    | Some s -> (
+        match int_of_string_opt s with
+        | None ->
+            let msg = sprintf "Expected valid gprc-status header, got %s" s in
+            (Grpc.Status.Unknown, Some msg)
+        | Some i -> (
+            match Grpc.Status.code_of_int i with
+            | None ->
+                let msg = sprintf "Expected valid gprc-status code, got %i" i in
+                (Grpc.Status.Unknown, Some msg)
+            | Some c -> (c, H2.Headers.get headers "grpc-message")))
+  in
+  let status = Grpc.Status.v ?message code in
+  Ivar.fill trailers_status_ivar status
+
+let response_handler read_body_ivar out_ivar (response : H2.Response.t)
+    (body : H2.Body.Reader.t) =
+  Ivar.fill read_body_ivar body;
+  Ivar.fill out_ivar response
+
 let call ~service ~rpc ?(scheme = "https") ~handler ~do_request
     ?(headers = default_headers) () =
   let request = make_request ~service ~rpc ~scheme ~headers in
   let read_body_ivar = Ivar.create () in
-  let handler_res_ivar = Ivar.create () in
   let out_ivar = Ivar.create () in
   let trailers_status_ivar = Ivar.create () in
-  let trailers_handler headers =
-    let code =
-      match H2.Headers.get headers "grpc-status" with
-      | None -> None
-      | Some s -> (
-          match int_of_string_opt s with
-          | None -> None
-          | Some i -> Grpc.Status.code_of_int i)
-    in
-    match code with
-    | None -> ()
-    | Some code -> (
-        match Ivar.is_empty trailers_status_ivar with
-        | true ->
-            let message = H2.Headers.get headers "grpc-message" in
-            let status = Grpc.Status.v ?message code in
-            Ivar.fill trailers_status_ivar status
-        | _ -> (* This should never happen, but just in case. *) ())
-  in
-  let response_handler (response : H2.Response.t) (body : H2.Body.Reader.t) =
-    Ivar.fill read_body_ivar body;
-    don't_wait_for
-      (match response.status with
-      | `OK ->
-          let%bind handler_res = Ivar.read handler_res_ivar in
-          Ivar.fill out_ivar (Ok handler_res);
-          return ()
-      | _ ->
-          Ivar.fill out_ivar (Error (Grpc.Status.v Grpc.Status.Unknown));
-          return ());
-    trailers_handler response.headers
-  in
-  let flush_headers_immediately = None in
   let write_body : H2.Body.Writer.t =
-    do_request ?flush_headers_immediately
-      ?trailers_handler:(Some trailers_handler) request ~response_handler
+    do_request ?flush_headers_immediately:None
+      ?trailers_handler:(Some (trailers_handler trailers_status_ivar))
+      request
+      ~response_handler:(response_handler read_body_ivar out_ivar)
   in
-  don't_wait_for
-    (let%bind handler_res = handler write_body (Ivar.read read_body_ivar) in
-     Ivar.fill handler_res_ivar handler_res;
-     return ());
-  let%bind out = Ivar.read out_ivar in
-  let%bind trailers_status =
-    (* In case no grpc-status appears in headers or trailers. *)
-    if Ivar.is_full trailers_status_ivar then Ivar.read trailers_status_ivar
-    else
-      return
-        (Grpc.Status.v ~message:"Server did not return grpc-status"
-           Grpc.Status.Unknown)
+  let%bind handler_res = handler write_body (Ivar.read read_body_ivar) in
+  let%bind response = Ivar.read out_ivar in
+  let out =
+    match response.status with
+    | `OK -> Ok handler_res
+    | _ -> Error (Grpc.Status.v Grpc.Status.Unknown)
   in
+  let%bind trailers_status = Ivar.read trailers_status_ivar in
   match out with
   | Error _ as e -> return e
   | Ok out -> return (Ok (out, trailers_status))

--- a/lib/grpc-lwt/client.ml
+++ b/lib/grpc-lwt/client.ml
@@ -66,8 +66,11 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~(do_request : do_request)
     if response.status <> `OK then Error (Grpc.Status.v Grpc.Status.Unknown)
     else Ok handler_res
   in
-  let+ status = status in
-  match out with Error _ as e -> e | Ok out -> Ok (out, status)
+  match out with
+  | Error _ as e -> Lwt.return e
+  | Ok out ->
+      let+ status = status in
+      Ok (out, status)
 
 module Rpc = struct
   type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t Lwt.t -> 'a Lwt.t

--- a/lib/grpc/status.mli
+++ b/lib/grpc/status.mli
@@ -37,3 +37,7 @@ val code : t -> code
 
 val message : t -> string option
 (** [message t] returns the message associated with [t], if there is one. *)
+
+val extract_status : H2.Headers.t -> t
+(** [extract_status headers] returns the status embedded in the headers, or a default
+    when the status is invalid or missing. *)


### PR DESCRIPTION
We recently noticed that we were getting Status = Unknown with the default message "Server did not return grpc-status", when a server was in fact responding properly with a non-default value. 

We now reproduced the issue in both `grpc-async` and `grpc-lwt`, using a variation of the greeter client example, with repeated requests. It seems that we randomly fail to get the real status, and we are filling in the default. 

This seems to be a race condition due to the way this is implemented, by checking if a future is filled when in fact it is simply not filled yet.

### How to reproduce 

See branch `reproduce/unknown-status-issue` for a reproduction of the issue. 
(https://github.com/dialohq/ocaml-grpc/tree/reproduce/unknown-status-issue.)

Run this in one terminal:

- `dune exec -- examples/greeter-server-lwt/greeter_server_lwt.exe`

Then run either of the following and it should blow up at some random (numbered) message: 

- `dune exec -- examples/greeter-test-async/test_grpc_status_async.exe test` 
- `dune exec -- examples/greeter-test-lwt/test_grpc_status_lwt.exe test` 

### Check solution 

See branch `test/unknown-status-issue`, which contains the same commits that are in this branch (the solution), on top of the code to reproduce the issue. 
(https://github.com/dialohq/ocaml-grpc/tree/test/unknown-status-issue.)

Run the same commands as above and after 100_000 iterations the programs should terminate without error. 
(Feel free to remove or increase the limit, I tested without it but it's convenient.)

### Assumptions

We assume that trailers only responses are not an issue, and we should never hang when there is no body in the response. This is consistent with expectations of HTTP2, so any hangs would probably indicate an issue with the underlying HTTP2 library and should probably be addressed there.

Should be tested with the etcd example, see https://github.com/dialohq/ocaml-grpc/issues/1. 
Could it be an etcd / proxy issue? I think there might be a missing trailer handler, but the situation needs some confirmation.

### Update (13-Apr-2023)

Refactored the code a bit. 

- Renamed the reproduction tests to avoid compilation errors, adding suffixes _lwt, _async. See above.
- The code to extract the status from headers does not depend on Lwt / Async any more, so it was moved to status.ml. 
- In my testing, when there was an immediate error we hanged waiting for the status to be filled from the trailers handler, which never happened. Now we only wait for this on Ok responses (which, of course, can contain a proper gRPC error status).
- When the response is Ok, we first check for the presence of grpc status in the headers, and if we don't find it there we block waiting for the trailers status. 