### PR TITLE
Fix message extraction behavior for batched messages

### DIFF
--- a/lib/grpc-async/connection.ml
+++ b/lib/grpc-async/connection.ml
@@ -7,10 +7,9 @@ let grpc_recv_streaming body buffer_push =
   let rec on_read buffer ~off ~len =
     Grpc.Buffer.copy_from_bigstringaf ~src_off:off ~src:buffer
       ~dst:request_buffer ~length:len;
-    let message = Grpc.Message.extract request_buffer in
-    (match message with
-    | Some message -> Async.Pipe.write_without_pushback buffer_push message
-    | None -> ());
+    Grpc.Message.extract_all
+      (Async.Pipe.write_without_pushback buffer_push)
+      request_buffer;
     H2.Body.Reader.schedule_read body ~on_read ~on_eof
   in
   H2.Body.Reader.schedule_read body ~on_read ~on_eof

--- a/lib/grpc-eio/connection.ml
+++ b/lib/grpc-eio/connection.ml
@@ -4,12 +4,7 @@ let grpc_recv_streaming body message_buffer_writer =
   let rec on_read buffer ~off ~len =
     Grpc.Buffer.copy_from_bigstringaf ~src_off:off ~src:buffer
       ~dst:request_buffer ~length:len;
-    let message = Grpc.Message.extract request_buffer in
-    let () =
-      match message with
-      | Some message -> Seq.write message_buffer_writer message
-      | None -> ()
-    in
+    Grpc.Message.extract_all (Seq.write message_buffer_writer) request_buffer;
     H2.Body.Reader.schedule_read body ~on_read ~on_eof
   in
   H2.Body.Reader.schedule_read body ~on_read ~on_eof

--- a/lib/grpc-lwt/connection.ml
+++ b/lib/grpc-lwt/connection.ml
@@ -6,10 +6,7 @@ let grpc_recv_streaming body buffer_push =
   let rec on_read buffer ~off ~len =
     Grpc.Buffer.copy_from_bigstringaf ~src_off:off ~src:buffer
       ~dst:request_buffer ~length:len;
-    let message = Grpc.Message.extract request_buffer in
-    (match message with
-    | Some message -> buffer_push (Some message)
-    | None -> ());
+    Grpc.Message.extract_all (fun msg -> buffer_push (Some msg)) request_buffer;
     H2.Body.Reader.schedule_read body ~on_read ~on_eof
   in
   H2.Body.Reader.schedule_read body ~on_read ~on_eof

--- a/lib/grpc/message.ml
+++ b/lib/grpc/message.ml
@@ -47,3 +47,13 @@ let get_message_and_shift buf =
       Some message
 
 let extract buf = get_message_and_shift buf
+
+let extract_all f buf =
+  let rec loop () =
+    match extract buf with
+    | None -> ()
+    | Some message ->
+        f message;
+        loop ()
+  in
+  loop ()

--- a/lib/grpc/message.mli
+++ b/lib/grpc/message.mli
@@ -3,3 +3,6 @@ val make : string -> string
 
 val extract : Buffer.t -> string option
 (** [extract b] attempts to extract a gRPC message from [b]. *)
+
+val extract_all : (string -> unit) -> Buffer.t -> unit
+(** [extract_all f b] extracts and calls [f] on all gRPC messages from [b]. *)


### PR DESCRIPTION
Fixes #31.

From the [gRPC over HTTP2 spec](https://grpc.github.io/grpc/core/md_doc__p_r_o_t_o_c_o_l-_h_t_t_p2.html):
> DATA frame boundaries have no relation to Length-Prefixed-Message boundaries and implementations should make no assumptions about their alignment.

When multiple messages are batched and read into the buffer, only the first message was extracted. Remaining messages would not be extracted until the next invocation of `on_read`.

This affects both client and server (only the streaming modes) and all three implementations.