### PR TITLE
Update for base / core v0.16

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -63,18 +63,10 @@
    (>= 4.11))
   (grpc
    (= :version))
-  (h2
-   (>= 0.9.0))
-  (h2-async
-   (>= 0.9.0))
-  (async
-   (and (>= v0.15) (< v0.16)))
-  (ppx_jane
-   (and (>= v0.15) (< v0.16)))
+  (async (>= v0.16))
   stringext))
 
 (package
-
  (name grpc-examples)
  (synopsis "Various grpc examples")
  (description "Various grpc examples.")
@@ -84,12 +76,9 @@
   grpc-async
   grpc-eio
   (ocaml-protoc-plugin (>= 4.5))
-  (async
-   (and (>= v0.15) (< v0.16)))
-  (ppx_jane
-   (and (>= v0.15) (< v0.16)))
   ppx_deriving_yojson
   h2-lwt-unix
+  h2-async
   conduit-lwt-unix
   cohttp-lwt-unix
   tls-async

--- a/examples/routeguide-async/src/client.ml
+++ b/examples/routeguide-async/src/client.ml
@@ -171,7 +171,7 @@ let run_route_chat connection =
           (* Pause and wait for server reply. Not strictly necessary but it demonstrates that
              responses are streamed rather than arriving as one response.
           *)
-          let%bind () = Async.after (Time_unix.Span.of_string "1s") in
+          let%bind () = Async.after (Time_float_unix.Span.of_string "1s") in
 
           let%bind response = Pipe.read' reader in
           match response with

--- a/grpc-async.opam
+++ b/grpc-async.opam
@@ -22,10 +22,7 @@ depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.11"}
   "grpc" {= version}
-  "h2" {>= "0.9.0"}
-  "h2-async" {>= "0.9.0"}
-  "async" {>= "v0.15" & < "v0.16"}
-  "ppx_jane" {>= "v0.15" & < "v0.16"}
+  "async" {>= "v0.16"}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/grpc-examples.opam
+++ b/grpc-examples.opam
@@ -23,10 +23,9 @@ depends: [
   "grpc-async"
   "grpc-eio"
   "ocaml-protoc-plugin" {>= "4.5"}
-  "async" {>= "v0.15" & < "v0.16"}
-  "ppx_jane" {>= "v0.15" & < "v0.16"}
   "ppx_deriving_yojson"
   "h2-lwt-unix"
+  "h2-async"
   "conduit-lwt-unix"
   "cohttp-lwt-unix"
   "tls-async"


### PR DESCRIPTION
Minor fixes to support base/core v0.16, which I've validated on macOS and linux. 
Added some missing transitive dependencies that are not listed in opam files but are used in dune files.