### PR TITLE
Update to eio.0.11

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -95,7 +95,7 @@
   tls-async
   (lwt_ssl (>= 1.2.0))
   (mdx (and (>= 2.2.1) :with-test))
-  (eio_main (= 0.10))
+  (eio_main (>= 0.10))
   stringext))
 
 (package

--- a/examples/greeter-server-eio/greeter_server_eio.ml
+++ b/examples/greeter-server-eio/greeter_server_eio.ml
@@ -33,7 +33,8 @@ let connection_handler server sw =
   in
   fun socket addr ->
     H2_eio.Server.create_connection_handler ?config:None ~request_handler
-      ~error_handler addr socket
+      ~error_handler addr
+      (socket :> Eio.Flow.two_way)
 
 let serve server env =
   let port = 8080 in
@@ -55,7 +56,7 @@ let serve server env =
   print_endline "Try running:";
   print_endline "";
   print_endline
-    {| dune exec -- examples/greeter-client-lwt/greeter_client_lwt.exe <your_name> |};
+    {| dune exec -- examples/greeter-client-eio/greeter_client_eio.exe <your_name> |};
   listen ()
 
 let () =

--- a/examples/routeguide/src/server.ml
+++ b/examples/routeguide/src/server.ml
@@ -235,7 +235,8 @@ let connection_handler server sw =
   in
   fun socket addr ->
     H2_eio.Server.create_connection_handler ?config:None ~request_handler
-      ~error_handler addr socket
+      ~error_handler addr
+      (socket :> Eio.Flow.two_way)
 
 (* $MDX part-begin=server-main *)
 let serve server env =

--- a/grpc-examples.opam
+++ b/grpc-examples.opam
@@ -32,7 +32,7 @@ depends: [
   "tls-async"
   "lwt_ssl" {>= "1.2.0"}
   "mdx" {>= "2.2.1" & with-test}
-  "eio_main" {= "0.10"}
+  "eio_main" {>= "0.10"}
   "stringext"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Needs a `(socket :> Eio.Flow.two_way)` cast in the example code due to minor changes to the object types for `Eio.Flow.streaming` and `Eio.Flow.two_way`. This change is backwards compatible with eio.0.10 so I've left it as the lower bound here. 