### PR TITLE
Fix dependencies for `eio` and `async`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -74,7 +74,7 @@
  (depends
   (grpc
    (= :version))
-   eio
+  (eio (>= 0.12))
    stringext))
 
 (package
@@ -96,7 +96,7 @@
   tls-async
   (lwt_ssl (>= 1.2.0))
   (mdx (and (>= 2.2.1) :with-test))
-  (eio_main (>= 0.10))
+  (eio_main (>= 0.12))
   stringext))
 
 (package

--- a/examples/greeter-client-eio/greeter_client_eio.ml
+++ b/examples/greeter-client-eio/greeter_client_eio.ml
@@ -16,8 +16,7 @@ let main env =
     let addr = `Tcp (Eio_unix.Net.Ipaddr.of_unix inet, port) in
     let socket = Eio.Net.connect ~sw network addr in
     let connection =
-      H2_eio.Client.create_connection ~sw ~error_handler:ignore
-        (socket :> Eio.Flow.two_way)
+      H2_eio.Client.create_connection ~sw ~error_handler:ignore socket
     in
 
     let open Ocaml_protoc_plugin in

--- a/examples/greeter-server-eio/greeter_server_eio.ml
+++ b/examples/greeter-server-eio/greeter_server_eio.ml
@@ -33,8 +33,7 @@ let connection_handler server sw =
   in
   fun socket addr ->
     H2_eio.Server.create_connection_handler ?config:None ~request_handler
-      ~error_handler addr
-      (socket :> Eio.Flow.two_way)
+      ~error_handler addr ~sw socket
 
 let serve server env =
   let port = 8080 in

--- a/examples/routeguide-async/src/dune
+++ b/examples/routeguide-async/src/dune
@@ -10,7 +10,7 @@
   core
   core_unix.command_unix
   routeguide_proto_async
-  h2-lwt-unix
+  h2-async
   yojson
   ppx_deriving_yojson.runtime)
  (preprocess

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -285,7 +285,7 @@ Now let's look at something a little more complicated: the client-side streaming
 
 <!-- $MDX include,file=routeguide/src/server.ml,part=server-record-route -->
 ```ocaml
-let record_route (clock : #Eio.Time.clock) (stream : string Seq.t) =
+let record_route (clock : _ Eio.Time.clock)  (stream : string Seq.t) =
   Eio.traceln "RecordRoute";
 
   let last_point = ref None in
@@ -378,7 +378,7 @@ let serve server env =
   let clock = Eio.Stdenv.clock env in
   let addr = `Tcp (Eio.Net.Ipaddr.V4.loopback, port) in
   Eio.Switch.run @@ fun sw ->
-  let handler = connection_handler (server clock) sw in
+  let handler = connection_handler ~sw (server clock) in
   let server_socket =
     Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:10 addr
   in
@@ -425,8 +425,7 @@ let client ~sw host port network =
   in
   let addr = `Tcp (Eio_unix.Net.Ipaddr.of_unix inet, port) in
   let socket = Eio.Net.connect ~sw network addr in
-  H2_eio.Client.create_connection ~sw ~error_handler:ignore
-    (socket :> Eio.Flow.two_way)
+  H2_eio.Client.create_connection ~sw ~error_handler:ignore  socket
 ```
 
 To call service methods, we take the H2 connection and build up a gRPC call for the service method using `Client.call` from the Client module.

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -285,7 +285,7 @@ Now let's look at something a little more complicated: the client-side streaming
 
 <!-- $MDX include,file=routeguide/src/server.ml,part=server-record-route -->
 ```ocaml
-let record_route (clock : _ Eio.Time.clock)  (stream : string Seq.t) =
+let record_route (clock : _ Eio.Time.clock) (stream : string Seq.t) =
   Eio.traceln "RecordRoute";
 
   let last_point = ref None in
@@ -425,7 +425,7 @@ let client ~sw host port network =
   in
   let addr = `Tcp (Eio_unix.Net.Ipaddr.of_unix inet, port) in
   let socket = Eio.Net.connect ~sw network addr in
-  H2_eio.Client.create_connection ~sw ~error_handler:ignore  socket
+  H2_eio.Client.create_connection ~sw ~error_handler:ignore socket
 ```
 
 To call service methods, we take the H2 connection and build up a gRPC call for the service method using `Client.call` from the Client module.

--- a/examples/routeguide/src/client.ml
+++ b/examples/routeguide/src/client.ml
@@ -15,8 +15,7 @@ let client ~sw host port network =
   in
   let addr = `Tcp (Eio_unix.Net.Ipaddr.of_unix inet, port) in
   let socket = Eio.Net.connect ~sw network addr in
-  H2_eio.Client.create_connection ~sw ~error_handler:ignore
-    (socket :> Eio.Flow.two_way)
+  H2_eio.Client.create_connection ~sw ~error_handler:ignore  socket
 
 (* $MDX part-end *)
 (* $MDX part-begin=client-get-feature *)

--- a/examples/routeguide/src/client.ml
+++ b/examples/routeguide/src/client.ml
@@ -15,7 +15,7 @@ let client ~sw host port network =
   in
   let addr = `Tcp (Eio_unix.Net.Ipaddr.of_unix inet, port) in
   let socket = Eio.Net.connect ~sw network addr in
-  H2_eio.Client.create_connection ~sw ~error_handler:ignore  socket
+  H2_eio.Client.create_connection ~sw ~error_handler:ignore socket
 
 (* $MDX part-end *)
 (* $MDX part-begin=client-get-feature *)

--- a/examples/routeguide/src/server.ml
+++ b/examples/routeguide/src/server.ml
@@ -130,7 +130,7 @@ let list_features (buffer : string) (f : string -> unit) =
 
 (* $MDX part-end *)
 (* $MDX part-begin=server-record-route *)
-let record_route (clock : _ Eio.Time.clock)  (stream : string Seq.t) =
+let record_route (clock : _ Eio.Time.clock) (stream : string Seq.t) =
   Eio.traceln "RecordRoute";
 
   let last_point = ref None in

--- a/grpc-eio.opam
+++ b/grpc-eio.opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
   "grpc" {= version}
-  "eio"
+  "eio" {>= "0.12"}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/grpc-examples.opam
+++ b/grpc-examples.opam
@@ -32,7 +32,7 @@ depends: [
   "tls-async"
   "lwt_ssl" {>= "1.2.0"}
   "mdx" {>= "2.2.1" & with-test}
-  "eio_main" {>= "0.10"}
+  "eio_main" {>= "0.12"}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/lib/grpc-async/dune
+++ b/lib/grpc-async/dune
@@ -1,6 +1,6 @@
 (library
  (name grpc_async)
  (public_name grpc-async)
- (libraries grpc h2 h2-async stringext async)
+ (libraries grpc h2 stringext async)
  (preprocess
   (pps ppx_jane)))

--- a/lib/grpc-eio/dune
+++ b/lib/grpc-eio/dune
@@ -1,4 +1,4 @@
 (library
  (name grpc_eio)
  (public_name grpc-eio)
- (libraries grpc h2-eio))
+ (libraries grpc h2 eio))


### PR DESCRIPTION
We don't require the `h2-{async,eio,lwt}` packages anymore in the `.opam` files, so we can't have them in the `dune` files either.

This was inadvertently broken when making the dependencies more consistent. It's hard to find in OCaml-CI because it installs the dependencies of all packages first (and the examples pull in everything):
```
RUN opam update --depexts && opam install --cli=2.1 --depext-only -y grpc.dev grpc-lwt.dev grpc-examples.dev grpc-eio.dev grpc-bench.dev grpc-async.dev $DEPS
RUN opam install $DEPS
COPY --chown=1000:1000 . /src
RUN opam exec -- dune build @install @check @runtest && rm -rf _build
```
(But it caused the Windows workflow to fail.)

OPAM in contrast checks package by package. Can we do that too?