### PR TITLE
Add dependencies to fix `opam-dune-lint`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -34,11 +34,11 @@
  (depends
   (ocaml
    (>= 4.08))
-  (uri
-   (>= 4.0.0))
   (h2
    (>= 0.9.0))
-  ppx_deriving))
+  ppx_deriving
+  (uri
+   (>= 4.0.0))))
 
 (package
  (name grpc-lwt)
@@ -64,10 +64,10 @@
  (depends
   (ocaml
    (>= 4.11))
-  (grpc
-   (= :version))
   (async
    (>= v0.16))
+  (grpc
+   (= :version))
   stringext))
 
 (package
@@ -76,10 +76,10 @@
  (description
   "Functionality for building gRPC services and rpcs with `eio`.")
  (depends
-  (grpc
-   (= :version))
   (eio
    (>= 0.12))
+  (grpc
+   (= :version))
   stringext))
 
 (package
@@ -89,27 +89,27 @@
  (tags
   (network rpc serialisation))
  (depends
-  grpc-lwt
-  h2-lwt-unix
-  grpc-async
-  h2-async
-  grpc-eio
-  h2-eio
-  (ocaml-protoc-plugin
-   (>= 4.5))
-  ppx_deriving_yojson
-  conduit-lwt-unix
   cohttp-lwt-unix
-  tls-async
+  conduit-lwt-unix
+  (eio_main
+   (>= 0.12))
+  grpc-async
+  grpc-eio
+  grpc-lwt
+  h2-async
+  h2-eio
+  h2-lwt-unix
   (lwt_ssl
    (>= 1.2.0))
   (mdx
    (and
     (>= 2.2.1)
     :with-test))
-  (eio_main
-   (>= 0.12))
-  stringext))
+  (ocaml-protoc-plugin
+   (>= 4.5))
+  ppx_deriving_yojson
+  stringext
+  tls-async))
 
 (package
  (name grpc-bench)
@@ -118,13 +118,12 @@
  (tags
   (network rpc serialisation benchmark))
  (depends
-  grpc
   (bechamel
    (>= 0.4.0))
-  notty
   (bechamel-notty
    (>= 0.4.0))
   (bigstringaf
    (>= 0.9.1))
+  grpc
   (notty
    (>= 0.2.3))))

--- a/dune-project
+++ b/dune-project
@@ -34,6 +34,8 @@
  (depends
   (ocaml
    (>= 4.08))
+  (bigstringaf
+   (>= 0.9.1))
   (h2
    (>= 0.9.0))
   ppx_deriving
@@ -50,6 +52,8 @@
  (depends
   (grpc
    (= :version))
+  (h2
+   (>= 0.9.0))
   (lwt
    (>= 5.3.0))
   stringext))
@@ -68,6 +72,10 @@
    (>= v0.16))
   (grpc
    (= :version))
+  (h2
+   (>= 0.9.0))
+  (ppx_jane
+   (>= v0.16.0))
   stringext))
 
 (package
@@ -80,6 +88,8 @@
    (>= 0.12))
   (grpc
    (= :version))
+  (h2
+   (>= 0.9.0))
   stringext))
 
 (package
@@ -89,16 +99,28 @@
  (tags
   (network rpc serialisation))
  (depends
+  (async
+   (>= v0.16.0))
+  cohttp
+  cohttp-lwt
   cohttp-lwt-unix
   conduit-lwt-unix
+  (core
+   (>= v0.16.2))
+  (core_unix
+   (>= v0.16.0))
   (eio_main
    (>= 0.12))
   grpc-async
   grpc-eio
   grpc-lwt
+  (h2
+   (>= 0.9.0))
   h2-async
   h2-eio
   h2-lwt-unix
+  (lwt
+   (>= 5.3.0))
   (lwt_ssl
    (>= 1.2.0))
   (mdx
@@ -107,9 +129,14 @@
     :with-test))
   (ocaml-protoc-plugin
    (>= 4.5))
+  ppx_deriving
   ppx_deriving_yojson
+  (ppx_jane
+   (>= v0.16.0))
   stringext
-  tls-async))
+  tls-async
+  (uri
+   (>= 4.0.0))))
 
 (package
  (name grpc-bench)

--- a/grpc-async.opam
+++ b/grpc-async.opam
@@ -23,6 +23,8 @@ depends: [
   "ocaml" {>= "4.11"}
   "async" {>= "v0.16"}
   "grpc" {= version}
+  "h2" {>= "0.9.0"}
+  "ppx_jane" {>= "v0.16.0"}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/grpc-async.opam
+++ b/grpc-async.opam
@@ -21,8 +21,8 @@ bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.11"}
-  "grpc" {= version}
   "async" {>= "v0.16"}
+  "grpc" {= version}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/grpc-bench.opam
+++ b/grpc-bench.opam
@@ -19,11 +19,10 @@ doc: "https://dialohq.github.io/ocaml-grpc"
 bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
-  "grpc"
   "bechamel" {>= "0.4.0"}
-  "notty"
   "bechamel-notty" {>= "0.4.0"}
   "bigstringaf" {>= "0.9.1"}
+  "grpc"
   "notty" {>= "0.2.3"}
   "odoc" {with-doc}
 ]

--- a/grpc-eio.opam
+++ b/grpc-eio.opam
@@ -18,8 +18,8 @@ doc: "https://dialohq.github.io/ocaml-grpc"
 bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
-  "grpc" {= version}
   "eio" {>= "0.12"}
+  "grpc" {= version}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/grpc-eio.opam
+++ b/grpc-eio.opam
@@ -20,6 +20,7 @@ depends: [
   "dune" {>= "3.7"}
   "eio" {>= "0.12"}
   "grpc" {= version}
+  "h2" {>= "0.9.0"}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/grpc-examples.opam
+++ b/grpc-examples.opam
@@ -19,21 +19,21 @@ doc: "https://dialohq.github.io/ocaml-grpc"
 bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
-  "grpc-lwt"
-  "h2-lwt-unix"
-  "grpc-async"
-  "h2-async"
-  "grpc-eio"
-  "h2-eio"
-  "ocaml-protoc-plugin" {>= "4.5"}
-  "ppx_deriving_yojson"
-  "conduit-lwt-unix"
   "cohttp-lwt-unix"
-  "tls-async"
+  "conduit-lwt-unix"
+  "eio_main" {>= "0.12"}
+  "grpc-async"
+  "grpc-eio"
+  "grpc-lwt"
+  "h2-async"
+  "h2-eio"
+  "h2-lwt-unix"
   "lwt_ssl" {>= "1.2.0"}
   "mdx" {>= "2.2.1" & with-test}
-  "eio_main" {>= "0.12"}
+  "ocaml-protoc-plugin" {>= "4.5"}
+  "ppx_deriving_yojson"
   "stringext"
+  "tls-async"
   "odoc" {with-doc}
 ]
 build: [

--- a/grpc-examples.opam
+++ b/grpc-examples.opam
@@ -19,21 +19,31 @@ doc: "https://dialohq.github.io/ocaml-grpc"
 bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
+  "async" {>= "v0.16.0"}
+  "cohttp"
+  "cohttp-lwt"
   "cohttp-lwt-unix"
   "conduit-lwt-unix"
+  "core" {>= "v0.16.2"}
+  "core_unix" {>= "v0.16.0"}
   "eio_main" {>= "0.12"}
   "grpc-async"
   "grpc-eio"
   "grpc-lwt"
+  "h2" {>= "0.9.0"}
   "h2-async"
   "h2-eio"
   "h2-lwt-unix"
+  "lwt" {>= "5.3.0"}
   "lwt_ssl" {>= "1.2.0"}
   "mdx" {>= "2.2.1" & with-test}
   "ocaml-protoc-plugin" {>= "4.5"}
+  "ppx_deriving"
   "ppx_deriving_yojson"
+  "ppx_jane" {>= "v0.16.0"}
   "stringext"
   "tls-async"
+  "uri" {>= "4.0.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/grpc-lwt.opam
+++ b/grpc-lwt.opam
@@ -20,6 +20,7 @@ bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
   "grpc" {= version}
+  "h2" {>= "0.9.0"}
   "lwt" {>= "5.3.0"}
   "stringext"
   "odoc" {with-doc}

--- a/grpc.opam
+++ b/grpc.opam
@@ -21,6 +21,7 @@ bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.08"}
+  "bigstringaf" {>= "0.9.1"}
   "h2" {>= "0.9.0"}
   "ppx_deriving"
   "uri" {>= "4.0.0"}

--- a/grpc.opam
+++ b/grpc.opam
@@ -21,9 +21,9 @@ bug-reports: "https://github.com/dialohq/ocaml-grpc/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.08"}
-  "uri" {>= "4.0.0"}
   "h2" {>= "0.9.0"}
   "ppx_deriving"
+  "uri" {>= "4.0.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
So that it is easier to avoid duplicating entries, use a canonical order to sort the libraries.

The canonical order I used here was to put `ocaml` first, and then the rest of dependencies alphabetically.

~~Note that this PR is based on top of #49, so it is currently marked as draft.~~
- [x] rebased on top of #49 