### PR TITLE
Upgrade ocamlformat to version 0.26.1

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.24.1
+version=0.26.1
 ocaml-version=4.08


### PR DESCRIPTION
This PR upgrades the `ocamlformat` version to `0.26.1`. The upgrade doesn't introduce any formatting changes in the repository.

The motivation behind this upgrade is to leverage the features introduced in the recent versions of `odoc`, such as support for [tables](https://ocaml.github.io/odoc/odoc_for_authors.html#tables), while documenting PR #48.

The upgrade to `odoc.2.4.0` necessitates the upgrade of `ocamlformat` (I believe due to the dependency on `odoc-parser.2.4.0`). I haven't determined the minimum required version of ocamlformat - I thought upgrading to the latest version seems beneficial.

 - [x] Rebase and enable for review after #50 is merged