### PR TITLE
Grpc-lwt: fetch status code from response header

### DIFF
--- a/lib/grpc-lwt/client.ml
+++ b/lib/grpc-lwt/client.ml
@@ -44,8 +44,8 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~(do_request : do_request)
   match response.status with
   | `OK ->
       let+ status =
-        match H2.Headers.get headers "grpc-status" with
-        | Some _ -> Lwt.return (Grpc.Status.extract_status headers)
+        match H2.Headers.get response.headers "grpc-status" with
+        | Some _ -> Lwt.return (Grpc.Status.extract_status response.headers)
         | None -> status
       in
       Ok (handler_res, status)


### PR DESCRIPTION
In `Grpc_lwt.Client.call, after receiving the response, the function checks for the response status code from the headers of the request. When this is not found, the function waits to receive the trailers from the remote to infer the response status code. If the response does not include any trailer received, the function will hang. 

If needed, I can provide a working example where an ocaml grpc client hangs after calling a server implemented in rust/tonic, where the handler of the service returns status code `12: Unimplemented`. 

The client should look for the response status code from the headers of the response (not the request). The change is done in this PR.