### PR TITLE
Make it compiling with H2 v0.13.0.

### DIFF
--- a/lib/grpc-async/connection.ml
+++ b/lib/grpc-async/connection.ml
@@ -35,7 +35,7 @@ let grpc_send_streaming request encoder_stream status_mvar =
     Async.Pipe.iter encoder_stream ~f:(fun input ->
         let payload = Grpc.Message.make input in
         H2.Body.Writer.write_string body payload;
-        H2.Body.Writer.flush body (fun () -> ());
+        H2.Body.Writer.flush body (fun _ -> ());
         return ())
   in
   let%map status = Async.Mvar.take status_mvar in

--- a/lib/grpc-eio/connection.ml
+++ b/lib/grpc-eio/connection.ml
@@ -29,7 +29,7 @@ let grpc_send_streaming request encoder_stream status_promise =
     (fun input ->
       let payload = Grpc.Message.make input in
       H2.Body.Writer.write_string body payload;
-      H2.Body.Writer.flush body (fun () -> ()))
+      H2.Body.Writer.flush body (fun _ -> ()))
     encoder_stream;
   let status = Eio.Promise.await status_promise in
   H2.Reqd.schedule_trailers request

--- a/lib/grpc-lwt/connection.ml
+++ b/lib/grpc-lwt/connection.ml
@@ -35,7 +35,7 @@ let grpc_send_streaming request encoder_stream status_mvar =
       (fun input ->
         let payload = Grpc.Message.make input in
         H2.Body.Writer.write_string body payload;
-        H2.Body.Writer.flush body (fun () -> ()))
+        H2.Body.Writer.flush body (fun _ -> ()))
       encoder_stream
   in
   let+ status = Lwt_mvar.take status_mvar in


### PR DESCRIPTION
Minimal changes to make it compiling with the recent version of H2.
The H2 version 0.13 is needed to make it compatible with EIO 1.2.