### PR TITLE
grpc-eio: fix request-body deadlock against grpcio/grpc-core servers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Fix bug in Grpc-lwt-client to fetch status code from response header ([#58](https://github.com/dialohq/ocaml-grpc/pull/58)) ([acerone85](https://github.com/acerone85)) review by ([@quernd](https://github.com/quernd))
 - Update Async dependency to v0.17.0 ([#62](https://github.com/dialohq/ocaml-grpc/pull/62) ([@tmcgilchrist](https://github.com/tmcgilchrist))
+- grpc-eio: pipeline request DATA concurrently with response HEADERS, enabling interoperability with grpcio, grpc-core, and grpc-go ([#70](https://github.com/dialohq/ocaml-grpc/pull/70)) ([@rhysolsen](https://github.com/rhysolsen))
 
 ## 0.2.0 2023-10-23
 

--- a/dune-project
+++ b/dune-project
@@ -90,7 +90,12 @@
    (= :version))
   (h2
    (>= 0.9.0))
-  stringext))
+  stringext
+  (h2-eio :with-test)
+  (eio_main
+   (and
+    :with-test
+    (>= 0.12)))))
 
 (package
  (name grpc-examples)

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -560,7 +560,7 @@ let run_record_route connection =
       failwith (Printf.sprintf "HTTP2 error: %s" (H2.Status.to_string e))
 ```
 
-With this stream of points we setup another handler using `Client.Rpc.client_streaming`. `f` is a `Seq.writer` for sending encoded points to the server; `Seq.write f x` enqueues a frame and `Seq.close_writer f` signals end-of-stream. `response` is a `string option Promise.t` that resolves once the server has replied; we await it and decode the `RouteSummary`.
+With this stream of points we setup another handler using `Client.Rpc.client_streaming`. The type of the callback arguments is important to understand: `writer` is a `Seq.writer` for sending data down the gRPC stream to the server. Calling `Seq.write writer value` will send the encoded value to the server, while calling `Seq.close_writer writer` signals that we have finished streaming. Here you can see we iterate over all the points, writing each one to the stream, and when we have sent everything we close the writer to signal we are finished. `response` is a promise that resolves once the server has replied; we await it and decode the `RouteSummary`.
 
 ### Bidirectional streaming RPC
 
@@ -628,7 +628,7 @@ We start by generating a short sequence of locations, similar to how we did for 
       failwith (Printf.sprintf "HTTP2 error: %s" (H2.Status.to_string e))
 ```
 
-Then we again use the `Client.Rpc` module to setup a `bidirectional_streaming` handler (`val bidirectional_streaming : f:(string Seq.writer -> string Seq.t -> 'a) -> 'a handler`). `writer` is a `Seq.writer` for sending encoded notes; `reader` is a `Seq.t` of encoded responses. We define a recursive function `go` that sends a note with `Seq.write`, sleeps briefly to let the server echo it back, reads the next response with `Seq.uncons`, and recurses. When there are no more notes to send we call `Seq.close_writer writer` to signal end-of-stream.
+Then we again use the `Client.Rpc` module to setup a `bidirectional_streaming` handler with an interesting type signature: `val bidirectional_streaming : f:(string Seq.writer -> string Seq.t -> 'a) -> 'a handler`. Somewhat intimidating but hopefully understandable in context. The function `f` receives two arguments: a `Seq.writer` for sending notes to the server, and a `Seq.t` for reading the stream of responses coming back. Calling `Seq.write writer value` sends an encoded value to the stream, with the same semantics as before. The `string Seq.t` is the stream of `RouteNote` responses from the server, which we need to decode and print out. We define a recursive function `go` to fold over the list, sending `route_notes`, sleeping to wait for a server response, and printing out that response. When we run out of `route_notes` to send we call `Seq.close_writer writer` to tell the server we are done and it can stop listening.
 Other combinations of sending and receiving are possible, the reader is encouraged to try them out.
 
 ## Try it out!

--- a/examples/routeguide-tutorial.md
+++ b/examples/routeguide-tutorial.md
@@ -560,7 +560,7 @@ let run_record_route connection =
       failwith (Printf.sprintf "HTTP2 error: %s" (H2.Status.to_string e))
 ```
 
-With this stream of points we setup another handler using `Client.Rpc.client_streaming`. The type of the callback arguments is important to understand, `f` is the function for sending data down the gRPC stream to the server. Calling it with `f (Some value)` will send the value to the server, while calling it with `f None` signals that we have finished streaming.  Here you can see we iterate over all the points and call `f` with Some value, and when we have sent everything we call `f None` to signal we are finished. Then we decode the `response` provided and print it out.
+With this stream of points we setup another handler using `Client.Rpc.client_streaming`. `f` is a `Seq.writer` for sending encoded points to the server; `Seq.write f x` enqueues a frame and `Seq.close_writer f` signals end-of-stream. `response` is a `string option Promise.t` that resolves once the server has replied; we await it and decode the `RouteSummary`.
 
 ### Bidirectional streaming RPC
 
@@ -628,7 +628,7 @@ We start by generating a short sequence of locations, similar to how we did for 
       failwith (Printf.sprintf "HTTP2 error: %s" (H2.Status.to_string e))
 ```
 
-Then we again use the `Client.Rpc` module to setup a `bidirectional_streaming` function with an interesting type signature `val bidirectional_streaming f:(string Seq.writer -> string Seq.t -> 'a) -> 'a handler`. Somewhat intimidating but hopefully understandable in context. The function `f` represents the writer function for sending notes to the server, with the same semantics as before. Calling it with `Some value` represents sending a value to the stream and `f None` means there is no more data to write. The `string Seq.t` is the stream of `record_note` responses coming back from the server, which we need to decode and print out. We define a recursive function `go` to fold over the list, sending `route_notes`, sleeping to wait for a server response, and printing out that response. When we run out of `route_notes` to send we call `Seq.close_writer f` to tell the server we are done and it can stop listening.
+Then we again use the `Client.Rpc` module to setup a `bidirectional_streaming` handler (`val bidirectional_streaming : f:(string Seq.writer -> string Seq.t -> 'a) -> 'a handler`). `writer` is a `Seq.writer` for sending encoded notes; `reader` is a `Seq.t` of encoded responses. We define a recursive function `go` that sends a note with `Seq.write`, sleeps briefly to let the server echo it back, reads the next response with `Seq.uncons`, and recurses. When there are no more notes to send we call `Seq.close_writer writer` to signal end-of-stream.
 Other combinations of sending and receiving are possible, the reader is encouraged to try them out.
 
 ## Try it out!

--- a/grpc-eio.opam
+++ b/grpc-eio.opam
@@ -22,6 +22,8 @@ depends: [
   "grpc" {= version}
   "h2" {>= "0.9.0"}
   "stringext"
+  "h2-eio" {with-test}
+  "eio_main" {with-test & >= "0.12"}
   "odoc" {with-doc}
 ]
 build: [

--- a/lib/grpc-eio/client.ml
+++ b/lib/grpc-eio/client.ml
@@ -31,30 +31,28 @@ let make_trailers_handler () =
   in
   (status, trailers_handler)
 
-let get_response_and_bodies request =
-  let response, response_notify = Eio.Promise.create () in
-  let read_body, read_body_notify = Eio.Promise.create () in
-  let response_handler response body =
-    Eio.Promise.resolve response_notify response;
-    Eio.Promise.resolve read_body_notify body
-  in
-  let write_body = request ~response_handler in
-  let response = Eio.Promise.await response in
-  let read_body = Eio.Promise.await read_body in
-  (response, read_body, write_body)
-
 let call ~service ~rpc ?(scheme = "https") ~handler ~(do_request : do_request)
     ?(headers = default_headers) () =
   let request = make_request ~service ~rpc ~scheme ~headers in
   let status, trailers_handler = make_trailers_handler () in
-  let response, read_body, write_body =
-    get_response_and_bodies
-      (do_request ~flush_headers_immediately:true request ~trailers_handler)
+  let response_p, response_notify = Eio.Promise.create () in
+  let read_body_p, read_body_notify = Eio.Promise.create () in
+  let response_handler response body =
+    Eio.Promise.resolve response_notify response;
+    Eio.Promise.resolve read_body_notify body
   in
+  let write_body =
+    do_request ~flush_headers_immediately:true request ~trailers_handler
+      ~response_handler
+  in
+  (* The handler receives write_body immediately so it can pipeline request DATA
+     before response HEADERS arrive.  response_p and read_body_p are resolved
+     by response_handler once the server emits its HEADERS frame. *)
+  let result = handler write_body read_body_p in
+  let response = Eio.Promise.await response_p in
   match response.status with
   | `OK ->
       trailers_handler response.headers;
-      let result = handler write_body read_body in
       let status =
         match Eio.Promise.is_resolved status with
         (* In case no grpc-status appears in headers or trailers. *)
@@ -67,18 +65,29 @@ let call ~service ~rpc ?(scheme = "https") ~handler ~(do_request : do_request)
   | error_status -> Error error_status
 
 module Rpc = struct
-  type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t -> 'a
+  type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t Eio.Promise.t -> 'a
 
-  let bidirectional_streaming ~f write_body read_body =
+  let bidirectional_streaming ~f write_body read_body_p =
     let response_reader, response_writer = Seq.create_reader_writer () in
     let request_reader, request_writer = Seq.create_reader_writer () in
-    Connection.grpc_recv_streaming read_body response_writer;
     let res, res_notify = Eio.Promise.create () in
+    (* Two concurrent fibers, one per direction:
+       - Send side: drives f and grpc_send_streaming_client; no dependency
+         on response HEADERS.
+       - Recv side: awaits read_body_p (resolves when HEADERS arrive), then
+         registers h2 read callbacks that feed incoming data into
+         response_writer.  Callback registration is non-blocking; h2 drives
+         data delivery via its internal event loop. *)
     Eio.Fiber.both
       (fun () ->
-        Eio.Promise.resolve res_notify (f request_writer response_reader))
+        Eio.Fiber.both
+          (fun () ->
+            Eio.Promise.resolve res_notify (f request_writer response_reader))
+          (fun () ->
+            Connection.grpc_send_streaming_client write_body request_reader))
       (fun () ->
-        Connection.grpc_send_streaming_client write_body request_reader);
+        let read_body = Eio.Promise.await read_body_p in
+        Connection.grpc_recv_streaming read_body response_writer);
     Eio.Promise.await res
 
   let client_streaming ~f =

--- a/lib/grpc-eio/client.mli
+++ b/lib/grpc-eio/client.mli
@@ -1,5 +1,18 @@
 module Rpc : sig
-  type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t -> 'a
+  type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t Eio.Promise.t -> 'a
+  (** [handler] is a function that implements an RPC by sending and receiving
+      gRPC messages over a single HTTP/2 stream.
+
+      [write_body] is available immediately; the handler should begin sending
+      the request body without waiting for [read_body_p] to resolve.
+      [read_body_p] resolves to [H2.Body.Reader.t] once the server sends its
+      response HEADERS frame.
+
+      The gRPC over HTTP/2 protocol and RFC 9113 §5.1 place no ordering
+      constraint between client DATA frames and server HEADERS; a conforming
+      server may withhold response HEADERS until after END_STREAM.  Pipelining
+      [write_body] calls before awaiting [read_body_p] is therefore required
+      for correct interoperability. *)
 
   val bidirectional_streaming :
     f:(string Seq.writer -> string Seq.t -> 'a) -> 'a handler

--- a/lib/grpc-eio/test/dune
+++ b/lib/grpc-eio/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_concurrent_handler)
+ (libraries grpc grpc-eio h2 h2-eio eio_main))

--- a/lib/grpc-eio/test/test_concurrent_handler.ml
+++ b/lib/grpc-eio/test/test_concurrent_handler.ml
@@ -1,0 +1,137 @@
+(** Tests the invariant that {!Grpc_eio.Client.call} pipelines request DATA
+    frames independently of response HEADERS.
+
+    {b Normative basis}
+
+    {ul
+      {li {b \[GRPC-HTTP2\]} — gRPC over HTTP/2 protocol.
+          {{:https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md}}
+
+          The gRPC request/response flows are:
+
+          {v
+  Request  → Request-Headers *Length-Prefixed-Message EOS
+  Response → Response-Headers *Length-Prefixed-Message Trailers
+          v}
+
+          No ordering constraint relates client DATA to server HEADERS; a
+          conforming server may defer its HEADERS frame until after EOS.}
+
+      {li {b \[RFC9113 §5.1\]} — HTTP/2 stream state machine.
+          {{:https://www.rfc-editor.org/rfc/rfc9113#section-5.1}}
+
+          A server in the "open" state (client HEADERS received, END_STREAM
+          not yet received) is not required to send response HEADERS before
+          the client sends END_STREAM.}
+
+      {li {b \[GRPCIO-DISPATCH\]} — grpcio (Python) and grpc-core (C++)
+          dispatch the service handler only after END_STREAM is received;
+          those runtimes therefore cannot emit response HEADERS until the
+          complete request stream has arrived.
+          See also {{:https://github.com/grpc/grpc/issues/34893}}.}}
+
+    {b Design note}
+
+    Separating [write_body] (available immediately) from [read_body_p] (a
+    promise for the response body) is the natural decomposition when the two
+    directions are decoupled at the protocol level: the send path requires no
+    knowledge of when HEADERS arrive.  {!Rpc.bidirectional_streaming} expresses
+    this as two concurrent {!Eio.Fiber.both} fibers, the minimal structure
+    needed to model the independence.
+
+    {b Test structure}
+
+    [deferred_response_handler] withholds response HEADERS until END_STREAM is
+    received, instantiating the \[GRPCIO-DISPATCH\] constraint in-process.
+    {!Grpc_eio.Client.call} is exercised via {!Grpc_eio.Client.Rpc.unary};
+    the test asserts a clean round-trip with the expected payload and gRPC
+    status. *)
+
+(** [deferred_response_handler sw _addr reqd] reads the {b complete} request
+    body before sending {b any} response HEADERS, realizing the
+    \[GRPCIO-DISPATCH\] constraint: a server whose handler is dispatched only
+    after END_STREAM cannot emit response HEADERS any earlier. *)
+let deferred_response_handler sw _addr reqd =
+  Eio.Fiber.fork ~sw (fun () ->
+      let body = H2.Reqd.request_body reqd in
+      let eof_p, eof_r = Eio.Promise.create () in
+      (* h2 invokes these callbacks from its internal event loop; they must
+         not block.  [Eio.Promise.resolve] is non-blocking and safe here. *)
+      let rec on_read _bs ~off:_ ~len:_ =
+        H2.Body.Reader.schedule_read body ~on_eof ~on_read
+      and on_eof () = Eio.Promise.resolve eof_r () in
+      H2.Body.Reader.schedule_read body ~on_read ~on_eof;
+      (* Wait for END_STREAM before emitting any response HEADERS,
+         per the [GRPCIO-DISPATCH] constraint. *)
+      Eio.Promise.await eof_p;
+      let resp_body =
+        H2.Reqd.respond_with_streaming reqd ~flush_headers_immediately:true
+          (H2.Response.create `OK
+             ~headers:
+               (H2.Headers.of_list
+                  [ ("content-type", "application/grpc+proto") ]))
+      in
+      H2.Body.Writer.write_string resp_body (Grpc.Message.make "pong");
+      H2.Reqd.schedule_trailers reqd
+        (H2.Headers.of_list
+           [
+             ( "grpc-status",
+               string_of_int (Grpc.Status.int_of_code Grpc.Status.OK) );
+           ]);
+      H2.Body.Writer.close resp_body)
+
+let error_handler _addr ?request:_ _error _start_response = ()
+
+let () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  (* Bind to an ephemeral loopback port so the test can run in parallel with
+     other tests without port-allocation conflicts. *)
+  let server_socket =
+    Eio.Net.listen net ~sw ~reuse_addr:true ~backlog:1
+      (`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+  in
+  let port =
+    match Eio.Net.listening_addr server_socket with
+    | `Tcp (_, p) -> p
+    | `Unix _ -> assert false
+  in
+  let result = ref None in
+  Eio.Fiber.both
+    (fun () ->
+      (* Server: accept exactly one connection, handle it, then return.
+         The connection closes once the client calls [H2_eio.Client.shutdown],
+         at which point [create_connection_handler] returns and this fiber
+         completes naturally — unblocking [Eio.Fiber.both]. *)
+      let socket, addr = Eio.Net.accept ~sw server_socket in
+      H2_eio.Server.create_connection_handler
+        ~request_handler:(deferred_response_handler sw)
+        ~error_handler addr ~sw socket)
+    (fun () ->
+      let socket =
+        Eio.Net.connect ~sw net (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+      in
+      let conn =
+        H2_eio.Client.create_connection ~sw ~error_handler:ignore socket
+      in
+      (* The server above withholds response HEADERS until END_STREAM;
+         [Grpc_eio.Client.call] must complete the round-trip regardless. *)
+      result :=
+        Some
+          (Grpc_eio.Client.call ~service:"test.DeadlockCheck"
+             ~rpc:"UnaryMethod" ~scheme:"http"
+             ~do_request:(H2_eio.Client.request conn ~error_handler:ignore)
+             ~handler:(Grpc_eio.Client.Rpc.unary "ping" ~f:(fun r -> r))
+             ());
+      Eio.Promise.await (H2_eio.Client.shutdown conn));
+  match !result with
+  | Some (Ok (Some response, status)) ->
+      assert (response = "pong");
+      assert (Grpc.Status.code status = Grpc.Status.OK);
+      print_endline
+        "PASS: unary call completed against deferred-response server"
+  | Some (Ok (None, _)) -> failwith "FAIL: empty response body"
+  | Some (Error s) ->
+      failwith (Format.asprintf "FAIL: H2 error: %a" H2.Status.pp_hum s)
+  | None -> failwith "FAIL: client fiber did not set result"

--- a/lib/grpc-eio/test/test_concurrent_handler.ml
+++ b/lib/grpc-eio/test/test_concurrent_handler.ml
@@ -119,8 +119,8 @@ let () =
          [Grpc_eio.Client.call] must complete the round-trip regardless. *)
       result :=
         Some
-          (Grpc_eio.Client.call ~service:"test.DeadlockCheck"
-             ~rpc:"UnaryMethod" ~scheme:"http"
+          (Grpc_eio.Client.call ~service:"test.DeadlockCheck" ~rpc:"UnaryMethod"
+             ~scheme:"http"
              ~do_request:(H2_eio.Client.request conn ~error_handler:ignore)
              ~handler:(Grpc_eio.Client.Rpc.unary "ping" ~f:(fun r -> r))
              ());


### PR DESCRIPTION
## Problem

`Grpc_eio.Client.call` deadlocks when connecting to **grpcio (Python)**,
**grpc-core (C++)**, **grpc-go**, and other server implementations that
withhold response `HEADERS` until the client has sent `END_STREAM`.

### Root cause

The pre-fix implementation serialised request and response in the wrong
order:

```
get_response_and_bodies:
  write_body ← do_request ...          (* send HEADERS only *)
  response   ← Promise.await response  (* BLOCK waiting for server HEADERS *)
  (* ← handler never reaches this point *)
  handler write_body read_body         (* ← body never written *)
```

Meanwhile the server (grpcio / grpc-core) dispatches its handler only
after receiving `END_STREAM`.  Neither side makes progress — mutual
deadlock.

This is consistent with the gRPC over HTTP/2 protocol specification
([PROTOCOL-HTTP2.md](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md))
and RFC 9113 §5.1, neither of which requires a server to emit response
`HEADERS` before `END_STREAM` is received.  The behaviour is therefore
standards-conformant on the server side; the bug is in the client.

Note: `flush_headers_immediately:true` was already present, ensuring the
request `HEADERS` frame is flushed immediately.  That did not help
because no `DATA` frames were ever written.

### Relationship to existing PRs

- **PR #68** (approved Nov 2025, not yet merged): adds `error_handler`
  to `do_request` and uses `Eio.Fiber.first` to handle H2-level
  connection errors.  That PR addresses a different failure mode
  (H2 protocol errors, not the grpcio interop deadlock) and is
  orthogonal to this change.

- **PR #69**: fixes a buffer race in `grpc-async`; unrelated.

This PR is independent of both and can be merged alongside or after them.

## Fix

Change the handler type in `Rpc`:

```ocaml
(* before *)
type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t -> 'a

(* after *)
type 'a handler = H2.Body.Writer.t -> H2.Body.Reader.t Eio.Promise.t -> 'a
```

`call` now invokes the handler **immediately** with `write_body` (before
response headers arrive) and passes `read_body_p`, a promise that
resolves once the server sends its `HEADERS` frame.

`bidirectional_streaming` is restructured with two concurrent
`Eio.Fiber.both` fibers:

```
Eio.Fiber.both
  send-side: f request_writer + grpc_send_streaming_client   (* starts immediately *)
  recv-side: await read_body_p; grpc_recv_streaming          (* deferred until HEADERS *)
```

The send side can flush `DATA` frames before response `HEADERS` arrive.
This breaks the deadlock.

## Test

A new integration test (`lib/grpc-eio/test/test_concurrent_handler.ml`)
exercises the scenario in-process:

1. A mock H2 server withholds response `HEADERS` until it has read
   `END_STREAM` from the client (exactly replicating grpcio behaviour).
2. `Grpc_eio.Client.call` makes a unary call against it.
3. The test asserts the call completes without deadlock and returns the
   correct response and gRPC status.

The test module-level docstring cites [PROTOCOL-HTTP2.md], RFC 9113 §5.1,
RFC 9113 §6.9 (flow control), and the grpcio dispatch-after-EOS behaviour
(`grpc/grpc#34893`).

## Checklist

- [x] `dune build` passes
- [x] `dune test` passes (including the new integration test)
- [x] mdx documentation tests pass
- [x] All four `Rpc` combinators (`unary`, `server_streaming`,
      `client_streaming`, `bidirectional_streaming`) are updated
- [x] `.mli` updated with rationale docstring